### PR TITLE
Fix "cannot take the address of an rvalue" compile error

### DIFF
--- a/src/LSDJunctionNetwork.cpp
+++ b/src/LSDJunctionNetwork.cpp
@@ -3704,7 +3704,9 @@ void LSDJunctionNetwork::write_valley_hilltop_chi_profiles_to_csv(vector<int> so
 		// get the LSDChannel
 		LSDChannel new_channel(hilltop_node, final_node, downslope_chi, m_over_n, A_0, FlowInfo, ElevationRaster);
 		// write to csv
-		string jn_str = static_cast<ostringstream*>( &(ostringstream() << source_junction) )->str();
+		ostringstream tmp_str;
+		tmp_str << source_junction;
+		string jn_str = static_cast<ostringstream*>( &tmp_str )->str();
 		string output_csv_filename = DEM_ID+"_chan_profile_"+jn_str;
 		new_channel.write_channel_to_csv(output_path, output_csv_filename, FlowDistance);
 	}


### PR DESCRIPTION
This pull request fixes a compile error for some compilers (*clang* version 9.0.1, in my case but other compilers showed a similar error). The error comes up in `LSDJunctionNetwork.cpp`:
```bash
.../LSDTopoTools2/src/LSDJunctionNetwork.cpp:3707:48: error: cannot take the address of an rvalue of type 'std::__1::basic_ostringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
                string jn_str = static_cast<ostringstream*>( &(ostringstream() << source_junction) )->str();
                                                             ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
To fix, I just create a temporary variable and then take its reference. Maybe not the best fix but it seems to do the trick.